### PR TITLE
add optimised collect

### DIFF
--- a/src/ShortStrings.jl
+++ b/src/ShortStrings.jl
@@ -25,13 +25,17 @@ struct ShortString{T} <: AbstractString where T
 end
 
 Base.endof(s::ShortString) = Int(s.size_content & 0xf)
-Base.next(s::ShortString{T}, i::Int) where T = (Char((s.size_content << 8(i-1)) >> 8*(sizeof(T)-1)), i + 1)
+Base.next(s::ShortString, i::Int) = (Base.unsafe_getindex(s, i), i + 1)
 Base.sizeof(s::ShortString) = Int(s.size_content & 0xf)
 Base.print(s::ShortString) = print(s.size_content)
 Base.display(s::ShortString) = display(s.size_content)
 Base.convert(::ShortString, s::String) = ShortString(s)
 Base.convert(::String, ss::ShortString) = reduce(*, ss)
 Base.start(::ShortString) = 1
+
+
+Base.unsafe_getindex(s::ShortString{T}, i::Int) where T = Char((s.size_content << 8(i-1)) >> 8*(sizeof(T)-1))
+Base.collect(s::ShortString) = Base.unsafe_getindex.(s, 1:Base.endof(s))
 
 size_content(s::ShortString) = s.size_content
 

--- a/test/runtests.jl
+++ b/test/runtests.jl
@@ -20,3 +20,8 @@ a = ShortString{UInt32}.(r)
 @test all(ShortString3.(r) .== r)
 a = ShortString3.(r)
 @test fsort(a) |> issorted
+
+
+
+@test collect(ShortString3("abc")) == ['a', 'b', 'c']
+


### PR DESCRIPTION
I really wanted to be doing this via `reinterpret` or `unsafe_load` but apparently not possible.
https://github.com/JuliaLang/julia/issues/10140

But still avoiding the iterator stuff gives some speedup

Before:
```
julia> @btime collect(ShortString15("abcsefsges"))
  208.959 ns (1 allocation: 128 bytes)
```

After:
```
 julia> @btime collect2(ShortString15("abcsefsges")) 
  135.005 ns (1 allocation: 128 bytes)
```


Interestingly however `convert(::Type{String}, s:ShortString)=String(collect(s))`.
Because it has an extra allocation somewhere