### PR TITLE
Add codeunit(s::ShortString)

### DIFF
--- a/src/ShortStrings.jl
+++ b/src/ShortStrings.jl
@@ -23,6 +23,7 @@ end
 
 String(s::ShortString) = String(reinterpret(UInt8, [s.size_content|>ntoh])[1:sizeof(s)])
 
+Base.codeunit(s::ShortString) = codeunit(String(s))
 Base.codeunit(s::ShortString, i) = codeunits(String(s), i)
 Base.codeunit(s::ShortString, i::Integer) = codeunit(String(s), i)
 Base.codeunits(s::ShortString) = codeunits(String(s))


### PR DESCRIPTION
* Confusingly (to me), this should return the type of `codeunit(s, i)`

I ran across this when trying to serialize a `DataFrame` containing columns of `ShortString`s to feather format (using `FeatherFiles.jl`):

```
Error encountered while saving "tmp/test.feather".

Fatal error:
ERROR: LoadError: MethodError: no method matching codeunit(::ShortStrings.ShortString{UInt128})
Closest candidates are:
  codeunit(::AbstractString, !Matched::Integer) at strings/basic.jl:84
  codeunit(::ShortStrings.ShortString, !Matched::Any) at /Users/kevinsquire/.julia/packages/ShortStrings/n6ztj/src/ShortStrings.jl:36
  codeunit(!Matched::String) at strings/string.jl:86
  ...
```