### PR TITLE
Make equality checks faster and fix hash

### DIFF
--- a/src/base.jl
+++ b/src/base.jl
@@ -76,7 +76,7 @@ function ==(a::ShortString{S}, b::ShortString{S}) where S
 end
 function ==(a::ShortString{A}, b::ShortString{B}) where {A,B}
     ncodeunits(a) == ncodeunits(b) || return false
-    # compare if equal after droppign size bits and
+    # compare if equal after dropping size bits and
     # flipping so that the empty bytes are at the start
     ntoh(a.size_content & ~size_mask(A)) == ntoh(b.size_content & ~size_mask(B))
 end

--- a/src/base.jl
+++ b/src/base.jl
@@ -38,7 +38,7 @@ Base.lastindex(s::ShortString) = sizeof(s)
 Base.ncodeunits(s::ShortString) = sizeof(s)
 Base.print(s::ShortString) = print(String(s))
 Base.show(io::IO, str::ShortString) = show(io, String(str))
-Base.sizeof(s::ShortString{T}) where T = Int(s.size_content & size_mask(T))
+Base.sizeof(s::ShortString{T}) where T = Int(s.size_content & (size_mask(s) % UInt))
 
 size_nibbles(::Type{<:Union{UInt16, UInt32, UInt64, UInt128}}) = 1
 size_nibbles(::Type{<:Union{Int16, Int32, Int64, Int128}}) = 1
@@ -46,7 +46,8 @@ size_nibbles(::Type{<:Union{UInt256, UInt512, UInt1024}}) = 2
 size_nibbles(::Type{<:Union{Int256, Int512, Int1024}}) = 2
 size_nibbles(::Type{T}) where T = ceil(log2(sizeof(T))/4)
 
-size_mask(T) = UInt(exp2(4*size_nibbles(T)) - 1)
+size_mask(T) = T(exp2(4*size_nibbles(T)) - 1)
+size_mask(s::ShortString{T}) where T = size_mask(T)
 
 
 # function Base.getindex(s::ShortString, i::Integer)
@@ -59,7 +60,7 @@ size_mask(T) = UInt(exp2(4*size_nibbles(T)) - 1)
 
 Base.collect(s::ShortString) = collect(String(s))
 
-function ==(s::ShortString{S}, b::Union{String, SubString{String}) where S
+function ==(s::ShortString{S}, b::Union{String, SubString{String}}) where S
     ncodeunits(b) == ncodeunits(s) || return false
     return s == ShortString{S}(b)
 end
@@ -73,6 +74,13 @@ end
 function ==(a::ShortString{S}, b::ShortString{S}) where S
     return a.size_content == b.size_content
 end
+function ==(a::ShortString{A}, b::ShortString{B}) where {A,B}
+    ncodeunits(a) == ncodeunits(b) || return false
+    # compare if equal after droppign size bits and
+    # flipping so that the empty bytes are at the start
+    ntoh(a.size_content & ~size_mask(A)) == ntoh(b.size_content & ~size_mask(B))
+end
+
 
 promote_rule(::Type{String}, ::Type{ShortString{S}}) where S = String
 promote_rule(::Type{ShortString{T}}, ::Type{ShortString{S}}) where {T,S} = ShortString{promote_rule(T,S)}

--- a/src/base.jl
+++ b/src/base.jl
@@ -66,7 +66,7 @@ function ==(s::ShortString{S}, b::Union{String, SubString{String}}) where S
 end
 function ==(s::ShortString, b::AbstractString)
     # Could be a string type that might not use UTF8 encoding and that we don't have a
-    # constructor for. Defer to equality that that type probably has defined on `String`
+    # constructor for. Defer to equality that type probably has defined on `String`
     return String(s) == b
 end
 

--- a/src/base.jl
+++ b/src/base.jl
@@ -23,7 +23,7 @@ end
 
 String(s::ShortString) = String(reinterpret(UInt8, [s.size_content|>ntoh])[1:sizeof(s)])
 
-Base.codeunit(s::ShortString) = codeunit(String(s))
+Base.codeunit(s::ShortString) = UInt8
 Base.codeunit(s::ShortString, i) = codeunits(String(s), i)
 Base.codeunit(s::ShortString, i::Integer) = codeunit(String(s), i)
 Base.codeunits(s::ShortString) = codeunits(String(s))
@@ -59,10 +59,16 @@ size_mask(T) = UInt(exp2(4*size_nibbles(T)) - 1)
 
 Base.collect(s::ShortString) = collect(String(s))
 
-function ==(s::ShortString{S}, b::AbstractString) where S
+function ==(s::ShortString{S}, b::Union{String, SubString{String}) where S
     ncodeunits(b) == ncodeunits(s) || return false
     return s == ShortString{S}(b)
 end
+function ==(s::ShortString, b::AbstractString)
+    # Could be a string type that might not use UTF8 encoding and that we don't have a
+    # constructor for. Defer to equality that that type probably has defined on `String`
+    return String(s) == b
+end
+
 ==(a::AbstractString, b::ShortString) = b == a
 function ==(a::ShortString{S}, b::ShortString{S}) where S
     return a.size_content == b.size_content

--- a/src/hash.jl
+++ b/src/hash.jl
@@ -2,6 +2,4 @@ export hash
 
 import Base.hash
 
-Base.hash(x::ShortString, args...; kwargs...) = hash(x.size_content, args...; kwargs...)
-
-Base.hash(x::ShortString, h::UInt) = hash(x.size_content, h)
+Base.hash(x::ShortString, h::UInt) = hash(String(x), h)

--- a/test/hash.jl
+++ b/test/hash.jl
@@ -1,5 +1,0 @@
-using ShortStrings: ShortString, hash
-using Test
-
-
-@test hash(ShortString(10)) == hash(UInt(10))

--- a/test/runtests.jl
+++ b/test/runtests.jl
@@ -61,3 +61,16 @@ basic_test(ShortString{MyUInt2048}, 254)
 @test ss15"Short String!!!" === ShortString15("Short String!!!")
 @test ss7"ShrtStr" === ShortString7("ShrtStr")
 @test ss3"ss3" === ShortString3("ss3")
+
+
+@testset "equality of different sized ShortStrings" begin
+    @test ShortString15("ab") == ShortString3("ab")
+    @test ShortString3("ab") == ShortString15("ab")
+
+    @test ShortString30("x") != ShortString3("y")
+    @test ShortString30("y") != ShortString3("x")
+
+    # this one is too big to fit in the other
+    @test ShortString15("abcd") != ShortString3("ab")
+    @test ShortString3("ab") != ShortString15("abcd")
+end

--- a/test/runtests.jl
+++ b/test/runtests.jl
@@ -3,7 +3,6 @@ using BitIntegers: UInt256, UInt512, UInt1024, @define_integers
 using Test, Random
 
 include("getindex.jl")
-include("hash.jl")
 
 function basic_test(constructor, max_len)
     @testset "$constructor" begin
@@ -18,6 +17,7 @@ end
 function basic_test(string_type, constructor, max_len)
     r = string_type.(randstring.(1:max_len))
     @test all(constructor.(r) .== r)
+    @test all(hash(constructor.(r)) .== hash(r))
     a = constructor.(r)
     @test fsort(a) |> issorted
 

--- a/test/runtests.jl
+++ b/test/runtests.jl
@@ -23,6 +23,16 @@ function basic_test(string_type, constructor, max_len)
 
     @test collect(constructor("z"^max_len)) == fill('z', max_len)
     @test_throws ErrorException constructor("a"^(max_len+1))
+
+    # equality
+    @test constructor("c"^max_len) == "c"^max_len
+    @test "c"^max_len == constructor("c"^max_len)
+    @test constructor("c"^max_len) == constructor("c"^max_len)
+    @test constructor("c"^max_len) != constructor("d"^max_len)
+    @test constructor("c"^max_len) != constructor("c"^(max_len-1))
+    @test constructor("c"^(max_len-1)) != constructor("c"^max_len)
+    @test constructor("c"^max_len) != "c"^(max_len-1)
+    @test constructor("c"^(max_len-1)) != "c"^max_len
 end
 
 


### PR DESCRIPTION
solves #15 

With this PR:
```julia
julia> @btime $(ShortString15("abc")) == "abc";
  10.935 ns (0 allocations: 0 bytes)

julia> @btime $(ShortString15("abc")) == "abd";
  11.152 ns (0 allocations: 0 bytes)
```

Without this PR
```julia
julia> @btime $(ShortString15("abc")) == "abc";
  79.701 ns (3 allocations: 224 bytes)

julia> @btime $(ShortString15("abc")) == "abd";
  80.259 ns (3 allocations: 224 bytes)
```

This also correct the `hash` closing #21 