### PR TITLE
make cmp faster

### DIFF
--- a/src/base.jl
+++ b/src/base.jl
@@ -63,6 +63,10 @@ Base.collect(s::ShortString) = collect(String(s))
     String(s) == b
 end
 
+function Base.cmp(a::ShortString{S}, b::ShortString{S}) where S
+    return cmp(a.size_content, b.size_content)
+end
+
 promote_rule(::Type{String}, ::Type{ShortString{S}}) where S = String
 promote_rule(::Type{ShortString{T}}, ::Type{ShortString{S}}) where {T,S} = ShortString{promote_rule(T,S)}
 

--- a/test/runtests.jl
+++ b/test/runtests.jl
@@ -51,3 +51,22 @@ basic_test(ShortString{MyUInt2048}, 254)
 @test ss15"Short String!!!" === ShortString15("Short String!!!")
 @test ss7"ShrtStr" === ShortString7("ShrtStr")
 @test ss3"ss3" === ShortString3("ss3")
+
+
+@testset "cmp" begin
+    @test cmp(ShortString3("abc"), ShortString3("abc")) == 0
+    @test cmp(ShortString3("ab"), ShortString3("abc")) == -1
+    @test cmp(ShortString3("abc"), ShortString3("ab")) == 1
+    @test cmp(ShortString3("ab"), ShortString3("ac")) == -1
+    @test cmp(ShortString3("ac"), ShortString3("ab")) == 1
+    @test cmp(ShortString3("α"), ShortString3("a")) == 1
+    @test cmp(ShortString3("b"), ShortString3("β")) == -1
+
+    @test cmp(ShortString3("abc"), "abc") == 0
+    @test cmp(ShortString3("ab"), "abc") == -1
+    @test cmp(ShortString3("abc"), "ab") == 1
+    @test cmp(ShortString3("ab"), "ac") == -1
+    @test cmp(ShortString3("ac"), "ab") == 1
+    @test cmp(ShortString3("α"), "a") == 1
+    @test cmp(ShortString3("b"), "β") == -1
+end


### PR DESCRIPTION
This should in particular speed up sorting.
Because sorting calls `isless` and `isless` for `AbstractString`s just calls `cmp`.
It won't make other sorting alogorthms as good as radix sort but still should speed them up a bunch.

With this PR:

```julia
julia> @btime cmp(ShortString3("abc"), ShortString3("ab"))
  1.497 ns (0 allocations: 0 bytes)
1
```

Without this PR
```julia

julia> @btime cmp(ShortString3("abc"), ShortString3("ab"))
  521.452 ns (18 allocations: 1.31 KiB)
```

Right now this only special cases the easy case of `cmp(::ShortString{T}, ::ShortString{T})`
that is probably the most important case, since one rarely wants to e.g. sort hetrogeniously typed collection